### PR TITLE
Fix deadlock of new version of node-pty

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ ptyProcess.write('ls\r');
 - [ENiGMA½ BBS Software](https://github.com/NuSkooler/enigma-bbs): A modern BBS software with a nostalgic flair!
 - [Tinkerun](https://github.com/tinkerun/tinkerun): A new way of running Tinker.
 - [Tess](https://github.com/SquitchYT/Tess/): Hackable, simple and rapid terminal for the new era of technology 👍
+- [NxShell](https://nxshell.github.io/): An easy to use new terminal for Windows/Linux/MacOS platform.
 
 Do you use node-pty in your application as well? Please open a [Pull Request](https://github.com/Tyriar/node-pty/pulls) to include it here. We would love to have it in our list.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,3 +95,4 @@ jobs:
   - script: |
       NPM_AUTH_TOKEN="$(NPM_AUTH_TOKEN)" node ./scripts/publish.js
     displayName: 'Publish to npm'
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@
 jobs:
 - job: Linux
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   strategy:
     matrix:
       node_12_x:
@@ -83,7 +83,7 @@ jobs:
   - Windows
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
   - task: NodeTool@0
     inputs:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "Microsoft Corporation"
   },
-  "version": "0.10.0",
+  "version": "0.9.0-theia.6",
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./typings/node-pty.d.ts",

--- a/src/win/conpty.cc
+++ b/src/win/conpty.cc
@@ -318,8 +318,8 @@ static NAN_METHOD(PtyConnect) {
   auto envV = vectorFromString(env);
   LPWSTR envArg = envV.empty() ? nullptr : envV.data();
 
-  BOOL success = ConnectNamedPipe(handle->hIn, nullptr);
-  success = ConnectNamedPipe(handle->hOut, nullptr);
+  ConnectNamedPipe(handle->hIn, nullptr);
+  ConnectNamedPipe(handle->hOut, nullptr);
 
   // Attach the pseudoconsole to the client application we're creating
   STARTUPINFOEXW siEx{0};
@@ -442,6 +442,10 @@ static NAN_METHOD(PtyKill) {
       }
     }
 
+    DisconnectNamedPipe(handle->hIn);
+    DisconnectNamedPipe(handle->hOut);
+    CloseHandle(handle->hIn);
+    CloseHandle(handle->hOut);
     CloseHandle(handle->hShell);
   }
 

--- a/src/win/path_util.cc
+++ b/src/win/path_util.cc
@@ -52,7 +52,7 @@ std::wstring get_shell_path(std::wstring filename) {
 
   const wchar_t *filename_ = filename.c_str();
 
-  for (int i = 0; i < paths.size(); ++i) {
+  for (size_t i = 0; i < paths.size(); ++i) {
     std::wstring path = paths[i];
     wchar_t searchPath[MAX_PATH];
     ::PathCombineW(searchPath, const_cast<wchar_t*>(path.c_str()), filename_);

--- a/src/windowsConoutConnection.ts
+++ b/src/windowsConoutConnection.ts
@@ -2,12 +2,12 @@
  * Copyright (c) 2020, Microsoft Corporation (MIT License).
  */
 
-import { Worker } from 'worker_threads';
-import { Socket } from 'net';
-import { IDisposable } from './types';
-import { IWorkerData, ConoutWorkerMessage, getWorkerPipeName } from './shared/conout';
-import { join } from 'path';
-import { IEvent, EventEmitter2 } from './eventEmitter2';
+import { Worker } from "worker_threads";
+import { Socket } from "net";
+import { IDisposable } from "./types";
+import { IWorkerData, ConoutWorkerMessage, getWorkerPipeName } from "./shared/conout";
+import { join } from "path";
+import { IEvent, EventEmitter2 } from "./eventEmitter2";
 
 /**
  * The amount of time to wait for additional data after the conpty shell process has exited before
@@ -34,21 +34,23 @@ export class ConoutConnection implements IDisposable {
   private _isDisposed: boolean = false;
 
   private _onReady = new EventEmitter2<void>();
-  public get onReady(): IEvent<void> { return this._onReady.event; }
+  public get onReady(): IEvent<void> {
+    return this._onReady.event;
+  }
 
-  constructor(
-    private _conoutPipeName: string
-  ) {
+  constructor(private _conoutPipeName: string) {
     const workerData: IWorkerData = { conoutPipeName: _conoutPipeName };
-    const scriptPath = __dirname.replace('node_modules.asar', 'node_modules.asar.unpacked');
-    this._worker = new Worker(join(scriptPath, 'worker/conoutSocketWorker.js'), { workerData });
-    this._worker.on('message', (message: ConoutWorkerMessage) => {
+    const scriptPath = __dirname
+      .replace("node_modules.asar", "node_modules.asar.unpacked")
+      .replace("app.asar", "app.asar.unpacked");
+    this._worker = new Worker(join(scriptPath, "worker/conoutSocketWorker.js"), { workerData });
+    this._worker.on("message", (message: ConoutWorkerMessage) => {
       switch (message) {
         case ConoutWorkerMessage.READY:
           this._onReady.fire();
           return;
         default:
-          console.warn('Unexpected ConoutWorkerMessage', message);
+          console.warn("Unexpected ConoutWorkerMessage", message);
       }
     });
   }

--- a/src/windowsPtyAgent.ts
+++ b/src/windowsPtyAgent.ts
@@ -146,6 +146,16 @@ export class WindowsPtyAgent {
     // The conout socket must be ready out on another thread to avoid deadlocks
     this._conoutSocketWorker = new ConoutConnection(term.conout);
     this._conoutSocketWorker.onReady(() => {
+      if (this._useConpty) {
+        const connect = (this._ptyNative as IConptyNative).connect(
+          this._pty,
+          commandLine,
+          cwd,
+          env,
+          (c) => this._$onProcessExit(c)
+        );
+        this._innerPid = connect.pid;
+      }
       this._conoutSocketWorker.connectSocket(this._outSocket);
     });
     this._outSocket.on("connect", () => {
@@ -165,16 +175,7 @@ export class WindowsPtyAgent {
       this._inSocket.setEncoding("utf8");
     });
 
-    if (this._useConpty) {
-      const connect = (this._ptyNative as IConptyNative).connect(
-        this._pty,
-        commandLine,
-        cwd,
-        env,
-        (c) => this._$onProcessExit(c)
-      );
-      this._innerPid = connect.pid;
-    }
+    
   }
 
   public resize(cols: number, rows: number): void {


### PR DESCRIPTION
new version of node-pty would deadlock on electron13，windows
this pr did
1. merge master of microsoft/node-pty
2. move connect progress to worker.onReady.It;s the reason of node-pty deadlock on windows platform when use conpty.